### PR TITLE
If default values are defined, we skip setting the value and let the …

### DIFF
--- a/Historisation/histolayer.py
+++ b/Historisation/histolayer.py
@@ -54,9 +54,12 @@ class HistoLayer(Layer):
         histoFeature = QgsFeature(self.getVectorLayer().fields())
 
         histoFeature.setGeometry(QgsGeometry(currentFeature.geometry()))
-
-        for field in currentFeature.fields():
-            histoFeature.setAttribute(field.name(), currentFeature.attribute(field.name()))
+        
+        for field in currentFeature.fields():          
+            if isinstance(currentFeature.attribute(field.name()), str) is True and currentFeature.attribute(field.name()).endswith('()') is True:
+                histoFeature.setAttribute(field.name(), None)
+            else:
+                histoFeature.setAttribute(field.name(), currentFeature.attribute(field.name()))
 
         self._setStartDate(histoFeature, eventDate)
         self._setStartEventId(histoFeature, eventId)


### PR DESCRIPTION
…DB do its job

Before, it sends the function for default value as if it was text:
```
2021-05-26 14:37:32.083 CEST [10492] ERREUR:  syntaxe en entrÃ©e invalide pour le type uuid : Â« uuid_generate_v4() Â» au caractÃ¨re 423
2021-05-26 14:37:32.083 CEST [10492] INSTRUCTION :  INSERT INTO "amenagement"."at072_reseau_vtt_h"("geom","idobj","identifiant_unique_ct","niveau_principal_itineraire","niveau_itineraire_sm","itineraire_sm","no_itineraire_sm","difficulte","sens_circulation","longueur_m","cat_revetement_sm","remarque","saisie","operateur_saisie","mise_a_jour","operateur_mise_a_jour","start_date","end_date","start_event_id","end_event_id") VALUES (st_multi(st_geomfromwkb($1::bytea,2056)),'uuid_generate_v4()',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2021-05-26T14:37:32.095',NULL,16,NULL) RETURNING "histo_id"
2021-05-26 14:37:32.085 CEST [10492] ERREUR:  l'instruction prÃ©parÃ©e Â« addfeatures Â» n'existe pas
2021-05-26 14:37:32.085 CEST [10492] INSTRUCTION :  DEALLOCATE addfeatures
```

But I am not sure this is the best way to do it...
